### PR TITLE
Update README to include OAuth scope needed for personal access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ $ cargo install gh-stack
 ## Usage
 
 ```bash
+# Access token should have at least the `repo` scope
 $ export GHSTACK_OAUTH_TOKEN='<personal access token>'
 
 $ gh-stack


### PR DESCRIPTION
When setting this up, I wasn't sure what Oauth scopes I needed. I believe `repo` is the minimal scope needed to make gh-stack work.